### PR TITLE
Fixes segfault caused by GETINITGR request

### DIFF
--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -264,7 +264,7 @@ int return_result(int fd, int swap, uint32_t reqtype, void *key)
 		buf = malloc(buf_len);
 		if(!buf) return -1;
 		break;
-	case GETGRBYNAME: case GETGRBYGID:
+	case GETGRBYNAME: case GETGRBYGID: case GETINITGR:
 		l = list_head(&group_mods);
 		tmp = sysconf(_SC_GETGR_R_SIZE_MAX);
 		if(tmp < 0) buf_len = 4096;


### PR DESCRIPTION
Hi there,

In socket_handle.c, link_t *l is not initialised from a GETINITGR request and is seg faulting at line 217 as ((nss_initgroups_dyn)fn) is not pointing to a valid location. GDB trace below.


```
(gdb) run
Starting program: /usr/local/sbin/nscd 
[New LWP 4889]

Thread 1 "nscd" received signal SIGSEGV, Segmentation fault.
0x00005555555586c9 in nss_getkey (reqtype=reqtype@entry=15, fn=0x90660020696225ff, key=key@entry=0x55555575c820, res=res@entry=0x7fffffffeb60, buf=buf@entry=0x0, n=n@entry=0, ret=0x7fffffffeb44) at src/socket_handle.c:217
217			retval = ((nss_initgroups_dyn)fn)((char*)key, (gid_t)-1, &(initgroups_res->end), &(initgroups_res->alloc), &(initgroups_res->grps), UINT32_MAX, ret);

(gdb) where
#0  0x00005555555586c9 in nss_getkey (reqtype=reqtype@entry=15, fn=0x90660020696225ff, key=key@entry=0x55555575c820, res=res@entry=0x7fffffffeb60, buf=buf@entry=0x0, n=n@entry=0, ret=0x7fffffffeb44) at src/socket_handle.c:217
#1  0x0000555555558bf9 in return_result (swap=0, key=0x55555575c820, reqtype=15, fd=6) at src/socket_handle.c:297
#2  socket_handle (fd=5, timeout=-1, l=0x7ffff7dd4680 <__c_locale>, pthread_args=0x7fffffffeb50) at src/socket_handle.c:170
#3  0x0000555555555b23 in main (argc=<optimized out>, argv=<optimized out>) at src/main.c:232

```