### PR TITLE
src/socket_handle.c: Assign new buffer len to buf_len before returning.

### DIFF
--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -314,6 +314,7 @@ int return_result(int fd, int swap, uint32_t reqtype, void *key)
 					return -1;
 				}
 				buf = new_buf;
+				buf_len = new_len;
 			}
 		} while(status == NSS_STATUS_TRYAGAIN && ret == ERANGE);
 


### PR DESCRIPTION
This commit fixes a bug that causes musl-nscd to hang during queries
to group information instead of returning with an error.  There are
other errors in the same module, but this fixes the most immediate
bug.