### PR TITLE
Initialize semaphore properly.

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -27,6 +27,7 @@ uint32_t swap32(uint32_t);
 int write_pwd(int, int, struct passwd*);
 int write_grp(int, int, struct group*);
 int write_groups(int, int, size_t, gid_t*);
+int init_socket_handling(void);
 void socket_handle(int, int, locale_t, void*);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -229,5 +229,6 @@ int main(int argc, char **argv)
 
 	chdir("/");
 
+	if (init_socket_handling() < 0) die();
 	socket_handle(fd, -1, l, 0);
 }

--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -55,11 +55,17 @@ static int strtouid(const char *restrict buf, uint32_t *id)
 	return 0;
 }
 
+static sem_t sem;
+
+int init_socket_handling(void)
+{
+	return sem_init(&sem, 0, 0);
+}
+
 void socket_handle(int fd, int timeout, locale_t l, void *pthread_args)
 {
 	struct pollfd pollfd;
 	struct pthread_args args;
-	static sem_t sem;
 	pollfd.fd = fd;
 	pollfd.events = POLLIN;
 


### PR DESCRIPTION
sem_t objects are opaque and don't have a static initializer available.
For simplicity, add an init_socket_handling function which can be used
to initialize other global variables, if necessary.

Luckily musl behaves fine with a zero initialized sem_t, only
erroneously treating it as a process shared semaphore.