### PR TITLE
Allocate grps with the correct size.

### DIFF
--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -216,7 +216,7 @@ enum nss_status nss_getkey(uint32_t reqtype, void *fn, void *key, void *res, cha
 		initgroups_res = res;
 		initgroups_res->end = 0;
 		initgroups_res->alloc = NGROUPS_MAX + 1;
-		initgroups_res->grps = (gid_t*)malloc(sizeof(gid_t) * NGROUPS_MAX + 1);
+		initgroups_res->grps = (gid_t*)malloc(sizeof(gid_t) * initgroups_res->alloc);
 		retval = ((nss_initgroups_dyn)fn)((char*)key, (gid_t)-1, &(initgroups_res->end), &(initgroups_res->alloc), &(initgroups_res->grps), UINT32_MAX, ret);
 		break;
 	}


### PR DESCRIPTION
sizeof(gid_t) * NGROUPS_MAX + 1 != sizeof(gid_t) * (NGROUPS_MAX + 1)

Patch taken from
https://github.com/asquared/musl-nscd/commit/b521c9f4bf11cf8eb6992f9feb6724acb4883941