### PR TITLE
Fix resource leak in listening thread.

### DIFF
--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -106,8 +106,11 @@ void socket_handle(int fd, int timeout, locale_t l, void *pthread_args)
 		}
 		sem_trywait(&sem);
 		if(sem_trywait(&sem) == -1) {
-			if(pthread_create((pthread_t[]){}, 0, start_thread, pthread_args)) {
+			pthread_t thread;
+			if(pthread_create(&thread, 0, start_thread, pthread_args)) {
 				syslog(LOG_ERR, "error in pthread_create: %s", strerror_l(errno, l));
+			} else {
+				pthread_detach(thread);
 			}
 		} else {
 			sem_post(&sem);


### PR DESCRIPTION
The thread launched to listen on the socket while the nscd request is
processed was being written to a temporary thread_t. This means the
thread couldn't be pthread_join'd, which is what would release its
resources (which includes the memory allocated for the thread's stack),
and this allocation would live on until nscd is killed. To avoid having
to control the thread lifetime, we can simply pthread_detach it, which
makes it so returning from the thread function releases its resources.

This commit fixes an issue where practically each new nscd request would
add (thread stack size + guard page size) bytes to the memory in use by
nscd.