### PR TITLE
Decrease initial memory allocation for passwd and grp buffers

### DIFF
--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -21,9 +21,9 @@
 #include "modules.h"
 #include "list.h"
 
-/* might be too large as an initial value;
- * studying a better minimum buffer size could improve memory usage */
-#define BUF_LEN_DEFAULT 4096
+/* glibc's NSS_BUFLEN_PASSWD (from pwd/pwd.h) and NSS_BUFLEN_GROUP (from grp/grp.h)
+ * are set to 1024 and consider it a reasonable default */
+#define BUF_LEN_DEFAULT 1024
 
 static int return_result(int fd, int swap, uint32_t reqtype, void *key);
 

--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -24,6 +24,9 @@
 /* glibc's NSS_BUFLEN_PASSWD (from pwd/pwd.h) and NSS_BUFLEN_GROUP (from grp/grp.h)
  * are set to 1024 and consider it a reasonable default */
 #define BUF_LEN_DEFAULT 1024
+/* NGROUPS_MAX value for musl as of 1.2.2, might change
+ * to keep up with the kernel definition, so we define our own */
+#define INITGR_ALLOC 32
 
 static int return_result(int fd, int swap, uint32_t reqtype, void *key);
 
@@ -241,7 +244,7 @@ static enum nss_status nss_getkey(uint32_t reqtype, struct mod_passwd *mod_passw
 	case GETINITGR:
 		initgroups_res = res;
 		initgroups_res->end = 0;
-		initgroups_res->alloc = NGROUPS_MAX + 1;
+		initgroups_res->alloc = INITGR_ALLOC + 1;
 		initgroups_res->grps = (gid_t*)malloc(sizeof(gid_t) * initgroups_res->alloc);
 		retval = mod_group->nss_initgroups_dyn((char*)key, (gid_t)-1, &(initgroups_res->end), &(initgroups_res->alloc), &(initgroups_res->grps), UINT32_MAX, ret);
 		break;

--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -21,6 +21,10 @@
 #include "modules.h"
 #include "list.h"
 
+/* might be too large as an initial value;
+ * studying a better minimum buffer size could improve memory usage */
+#define BUF_LEN_DEFAULT 4096
+
 static int return_result(int fd, int swap, uint32_t reqtype, void *key);
 
 struct pthread_args {
@@ -57,10 +61,18 @@ static int strtouid(const char *restrict buf, uint32_t *id)
 	return 0;
 }
 
+static size_t buf_len_passwd, buf_len_group;
 static sem_t sem;
 
 int init_socket_handling(void)
 {
+	/* temporary variable needs to be signed */
+	long tmp;
+	tmp = sysconf(_SC_GETPW_R_SIZE_MAX);
+	buf_len_passwd = (tmp > 0) ? tmp : BUF_LEN_DEFAULT;
+	tmp = sysconf(_SC_GETGR_R_SIZE_MAX);
+	buf_len_group = (tmp > 0) ? tmp : BUF_LEN_DEFAULT;
+
 	return sem_init(&sem, 0, 0);
 }
 


### PR DESCRIPTION
As explained in commit, we don't use the buffer lengths yet, because it will be part of the refactoring necessary to add caching.