### PR TITLE
Error out if nsswitch.conf specifies merge action.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -122,6 +122,14 @@ int main(int argc, char **argv)
 		service_l = list_head(&entry->services);
 		while(service_l) {
 			service = list_ref(service_l, struct service, link);
+
+			for(size_t i = 0; i < 4; i++) {
+				/* TODO: implement ACT_MERGE */
+				if(service->on_status[i] == ACT_MERGE) {
+					die_fmt("service '%s' is configured with a merge action in '%s', this is unsupported", service->service, config_path);
+				}
+			}
+
 			if(entry->database == DB_PASSWD) {
 				void *dll, *fn;
 				struct mod_passwd *mod;

--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -340,7 +340,7 @@ int return_result(int fd, int swap, uint32_t reqtype, void *key)
 			status == NSS_STATUS_UNAVAIL ? STS_UNAVAIL :
 			status == NSS_STATUS_NOTFOUND ? STS_NOTFOUND :
 			STS_SUCCESS];
-		if(act == ACT_RETURN || act == ACT_MERGE) {
+		if(act == ACT_RETURN) {
 			int err;
 			if(mod_passwd)
 				err = write_pwd(fd, swap, status == NSS_STATUS_SUCCESS ? &res.p : 0);


### PR DESCRIPTION
The merge action isn't dealt with properly (it's mostly treated as a
return action), so we shouldn't pretend it is. Instead of removing it
completely, error out clearly and leave room for it being implemented
fully in the future.