### PR TITLE
Fix compiler warning in parser.

### DIFF
--- a/src/nsswitch.y
+++ b/src/nsswitch.y
@@ -7,7 +7,7 @@
 
 list_t parsed_output;
 
-int yyerror(const char*);
+void yyerror(const char*);
 
 static const action default_actions[] = {
 	ACT_RETURN,
@@ -126,7 +126,7 @@ list:
 
 %%
 
-int yyerror(const char *s)
+void yyerror(const char *s)
 {
 	fprintf(stderr, "%s\n", s);
 }


### PR DESCRIPTION
A non-void function should always return some value, and yyerror wasn't.
However, per [1], this function can be of any type, so we simply make it
void.

[1] https://www.gnu.org/software/bison/manual/html_node/Error-Reporting-Function.html