### PR TITLE
Fix use-of-uninitialized-value in return_result.

### DIFF
--- a/src/socket_handle.c
+++ b/src/socket_handle.c
@@ -290,7 +290,7 @@ int return_result(int fd, int swap, uint32_t reqtype, void *key)
 		if(!buf) return -1;
 	}
 	for(; l; l = list_next(l)) {
-		int ret;
+		int ret = 0;
 		int act;
 		enum nss_status status;
 		action *on_status;


### PR DESCRIPTION
Caught with clang's memory sanitizer: can happen when the function
called by nss_getkey doesn't set ret.