### PR TITLE
nsswitch: add support for the automount database

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -11,6 +11,7 @@ typedef unsigned char action;
 
 enum {
 	DB_ALIASES,
+	DB_AUTOMOUNT,
 	DB_ETHERS,
 	DB_GROUP,
 	DB_HOSTS,

--- a/src/nsswitch.l
+++ b/src/nsswitch.l
@@ -15,6 +15,7 @@
 <LIST,ACTION,COMMENT>"\n" { BEGIN INITIAL; return '\n'; }
 
 aliases:?	{ yylval.database = DB_ALIASES; BEGIN LIST; return TOK_DB; }
+automount:?	{ yylval.database = DB_AUTOMOUNT; BEGIN LIST; return TOK_DB; }
 ethers:?	{ yylval.database = DB_ETHERS; BEGIN LIST; return TOK_DB; }
 group:?		{ yylval.database = DB_GROUP; BEGIN LIST; return TOK_DB; }
 hosts:?		{ yylval.database = DB_HOSTS; BEGIN LIST; return TOK_DB; }


### PR DESCRIPTION
`automount` is a valid database for the name switch service.  This
allows processing the database entry in the configuration.  The service
now starts up rather than erroring out as it is unable to process the
configuration.